### PR TITLE
fix: Align API with embedded_hal_nb constraints (external delays)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [package.metadata.docs.rs]
-targets = [ "thumbv7m-none-eabi", "thumbv7em-none-eabihf" ]
+targets = ["thumbv7m-none-eabi", "thumbv7em-none-eabihf"]
 
 [dependencies]
-embedded-hal = "1.0.0"
+embedded-hal = "0.2.3"
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2021"
 targets = ["thumbv7m-none-eabi", "thumbv7em-none-eabihf"]
 
 [dependencies]
-embedded-hal = "0.2.3"
+embedded-hal-nb = "1.0.0"
 

--- a/src/calibration.rs
+++ b/src/calibration.rs
@@ -9,7 +9,7 @@ pub enum OversamplingRatio {
 }
 
 impl OversamplingRatio {
-    pub fn value(&self) -> u8 {
+    pub fn value(&self) -> u16 {
         match *self {
             OversamplingRatio::OSR256 => 0x00,
             OversamplingRatio::OSR512 => 0x02,
@@ -18,7 +18,7 @@ impl OversamplingRatio {
             OversamplingRatio::OSR4096 => 0x08,
         }
     }
-    pub fn delay(&self) -> u32 {
+    pub fn delay(&self) -> u16 {
         // 0.5 / 1.1 / 2.1 / 4.1 / 8.22 ms return in ns
         match *self {
             OversamplingRatio::OSR256 => 500_000,

--- a/src/calibration.rs
+++ b/src/calibration.rs
@@ -9,7 +9,7 @@ pub enum OversamplingRatio {
 }
 
 impl OversamplingRatio {
-    pub fn value(&self) -> u16 {
+    pub fn value(&self) -> u8 {
         match *self {
             OversamplingRatio::OSR256 => 0x00,
             OversamplingRatio::OSR512 => 0x02,
@@ -18,14 +18,14 @@ impl OversamplingRatio {
             OversamplingRatio::OSR4096 => 0x08,
         }
     }
-    pub fn delay(&self) -> u16 {
+    pub fn delay(&self) -> u8 {
         // 0.5 / 1.1 / 2.1 / 4.1 / 8.22 ms return in ns
         match *self {
-            OversamplingRatio::OSR256 => 500_000,
-            OversamplingRatio::OSR512 => 1_100_000,
-            OversamplingRatio::OSR1024 => 2_100_000,
-            OversamplingRatio::OSR2048 => 4_100_000,
-            OversamplingRatio::OSR4096 => 8_220_000,
+            OversamplingRatio::OSR256 => 1,
+            OversamplingRatio::OSR512 => 2,
+            OversamplingRatio::OSR1024 => 3,
+            OversamplingRatio::OSR2048 => 5,
+            OversamplingRatio::OSR4096 => 9,
         }
     }
 }

--- a/src/calibration.rs
+++ b/src/calibration.rs
@@ -1,5 +1,5 @@
 /// Oversampling Ratio
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum OversamplingRatio {
     OSR256,
     OSR512,
@@ -18,6 +18,8 @@ impl OversamplingRatio {
             OversamplingRatio::OSR4096 => 0x08,
         }
     }
+
+    /// Gets the required typical conversion delay in MILLISECONDS.
     pub fn delay(&self) -> u8 {
         // 0.5 / 1.1 / 2.1 / 4.1 / 8.22 ms return in ns
         match *self {
@@ -30,21 +32,29 @@ impl OversamplingRatio {
     }
 }
 
-#[derive(Clone, Copy)]
+/// Factory calibration data read from PROM
+#[derive(Clone, Copy, Debug)]
 pub struct Calibration {
-    pub sens: u16,
-    pub off: u16,
-    pub tcs: u16, // temperature coefficient of sensitivity
-    pub tco: u16, // temperature coefficient of offset
+    /// C1: Pressure sensitivity | SENST1
+    pub sens_t1: u16,
+    /// C2: Pressure offset | OFFT1
+    pub off_t1: u16,
+    /// C3: Temperature coefficient of pressure sensitivity | TCS
+    pub tcs: u16,
+    /// C4: Temperature coefficient of pressure offset | TCO
+    pub tco: u16,
+    /// C5: Reference temperature | TREF
     pub t_ref: u16,
+    /// C6: Temperature coefficient of the temperature | TEMPSENS
     pub temp_sens: u16,
+    // We don't store PROM[0] (manufacturer info) or PROM[7] (Serial/CRC) here
 }
 
 impl Calibration {
     pub fn new(buf: &[u16; 8]) -> Calibration {
         Calibration {
-            sens: buf[1],
-            off: buf[2],
+            sens_t1: buf[1],
+            off_t1: buf[2],
             tcs: buf[3],
             tco: buf[4],
             t_ref: buf[5],

--- a/src/command.rs
+++ b/src/command.rs
@@ -10,14 +10,12 @@ pub enum Command {
 }
 
 impl Command {
-    pub fn value(&self) -> u16 {
+    pub fn value(&self) -> u8 {
         match self {
             Command::Reset => 0x1E,
-            Command::ReadPROM(ad2, ad1, ad0) => {
-                (0xA0 | (ad2 << 1) | (ad1 << 2) | (ad0 << 3)) as u16
-            }
-            Command::D1Conversion(ratio) => (0x40 | ratio.value()) as u16,
-            Command::D2Conversion(ratio) => (0x50 | ratio.value()) as u16,
+            Command::ReadPROM(ad2, ad1, ad0) => 0xA0 | (ad2 << 1) | (ad1 << 2) | (ad0 << 3),
+            Command::D1Conversion(ratio) => 0x40 | ratio.value(),
+            Command::D2Conversion(ratio) => 0x50 | ratio.value(),
             Command::ReadADC => 0x00,
         }
     }

--- a/src/command.rs
+++ b/src/command.rs
@@ -10,12 +10,14 @@ pub enum Command {
 }
 
 impl Command {
-    pub fn value(&self) -> u8 {
+    pub fn value(&self) -> u16 {
         match self {
             Command::Reset => 0x1E,
-            Command::ReadPROM(ad2, ad1, ad0) => 0xA0 | (ad2 << 1) | (ad1 << 2) | (ad0 << 3),
-            Command::D1Conversion(ratio) => 0x40 | ratio.value(),
-            Command::D2Conversion(ratio) => 0x50 | ratio.value(),
+            Command::ReadPROM(ad2, ad1, ad0) => {
+                (0xA0 | (ad2 << 1) | (ad1 << 2) | (ad0 << 3)) as u16
+            }
+            Command::D1Conversion(ratio) => (0x40 | ratio.value()) as u16,
+            Command::D2Conversion(ratio) => (0x50 | ratio.value()) as u16,
             Command::ReadADC => 0x00,
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 #[derive(Copy, Clone, Debug)]
-pub enum DeviceError {
-    Io,
+pub enum DeviceError<SPI> {
+    Spi(SPI),
     UnderTemperature,
     OverTemperature,
     UnderPressure,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 #[derive(Copy, Clone, Debug)]
-pub enum DeviceError<SPI> {
-    Spi(SPI),
+pub enum DeviceError {
+    Io,
     UnderTemperature,
     OverTemperature,
     UnderPressure,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,236 +1,257 @@
 #![no_std]
-use embedded_hal::spi::FullDuplex;
+#![allow(clippy::needless_range_loop)] // Allow for i in 0..16 loop in CRC check
+
+use embedded_hal_nb::{nb, spi::FullDuplex};
+use nb::block;
+
 pub mod calibration;
 pub mod command;
 pub mod error;
+
 use calibration::{Calibration, OversamplingRatio};
 use command::Command;
 use error::DeviceError;
 
+// NOTE: Reset delay (~3ms) must be handled externally by the caller
+
+/// Driver for the MS5611-01BA03 pressure sensor using embedded-hal-nb.
+///
+/// This driver uses the non-blocking `FullDuplex` SPI trait and does *not*
+/// manage delays internally. The caller is responsible for inserting appropriate
+/// delays after reset and between starting a conversion and reading the result.
 pub struct MS5611_01BA<SPI>
 where
     SPI: FullDuplex<u8>,
+    SPI::Error: Clone,
 {
     spi: SPI,
-    calibration: Result<Calibration, DeviceError>, // a user can choose to calibrate the device
+    calibration: Result<Calibration, DeviceError<SPI::Error>>,
     oversampling_ratio: OversamplingRatio,
 }
 
 impl<SPI> MS5611_01BA<SPI>
 where
     SPI: FullDuplex<u8>,
+    SPI::Error: Clone,
 {
-    /// Create a new instance of the MS5611_01BA03
-    /// Clock speed must not exceed 20MHz
-    /// Accept mode 0 or 3.
-    /// Default to OSR1024
+    /// Creates a new driver instance and sends the Reset command.
+    ///
+    /// **IMPORTANT:** The caller MUST wait approximately 3ms after this function
+    /// returns successfully before calling `calibrate()` or any other command,
+    /// to allow the sensor to complete its reset sequence.
+    ///
+    /// The driver starts in an uncalibrated state. Call `calibrate()` after the reset delay.
+    ///
+    /// # Arguments
+    /// * `spi` - An SPI peripheral implementing `embedded_hal_nb::spi::FullDuplex<u8>`.
+    /// * `oversampling_ratio` - The desired default OSR for measurements.
     pub fn new(mut spi: SPI, oversampling_ratio: OversamplingRatio) -> Self {
-        // Should we calibrate in the constructor? No because this is beyond the scope of the constructor
-
-        let calibration = Self::calibrate(&mut spi);
+        // Send Reset command, ignore potential error during init
+        let _reset_res = block!(spi.write(Command::Reset.value())).map_err(DeviceError::Spi);
+        // NOTE: Caller MUST wait ~3ms externally NOW.
 
         Self {
             spi,
-            calibration,
+            calibration: Err(DeviceError::Uncalibrated), // Start uncalibrated
             oversampling_ratio,
         }
     }
-    /// Every module is individually factory calibrated at two temperatures and two pressures. As a result, 6 coefficients
-    /// necessary to compensate for process variations and temperature variations are calculated and stored in the 128-
-    /// bit PROM of each module. These bits (partitioned into 6 coefficients) must be read by the microcontroller software
-    /// and used in the program converting D1 and D2 into compensated pressure and temperature values.
-    /// This could just be a function of the device struct
-    /// Only needs to be called once.
-    fn calibrate(spi: &mut SPI) -> Result<Calibration, DeviceError> {
-        // Read PROM
-        // Calculate calibration values
-        //  Address 0 contains factory data and the setup, addresses 1-6 calibration coefficients and address 7 contains
-        // the serial code and CRC.
-        let mut buf = [0u16; 8]; // 16 bits
 
-        for i in 0..8 {
-            spi.send(Command::ReadPROM(i / 4, (i / 2) % 2, i % 2).value())
-                .map_err(|_| DeviceError::Io)?;
-            let temp_val = {
-                (spi.read().map_err(|_| DeviceError::Io)? as u16) << 8
-                    | spi.read().map_err(|_| DeviceError::Io)? as u16
-            };
-            buf[i as usize] = temp_val;
+    /// Reads calibration data from the sensor's PROM and validates the CRC.
+    ///
+    /// This function **MUST** be called after `new()` and after the external ~3ms
+    /// reset delay has elapsed. It updates the driver's internal calibration state.
+    pub fn calibrate(&mut self) -> Result<(), DeviceError<SPI::Error>> {
+        match Self::read_calibration_data(&mut self.spi) {
+            Ok(cal_data) => {
+                self.calibration = Ok(cal_data);
+                Ok(())
+            }
+            Err(e) => {
+                self.calibration = Err(e.clone()); // Store the error
+                Err(e) // Return the error
+            }
         }
-
-        // before setting calibration values, check CRC.
-        // 4 bit CRC
-        if !crc4(&mut buf) {
-            return Err(DeviceError::InvalidCRC);
-        }
-
-        let calibration = Calibration::new(&buf);
-
-        Ok(calibration)
     }
 
+    /// Static method to read all 8 PROM words and validate CRC. Called by `calibrate`.
+    fn read_calibration_data(spi: &mut SPI) -> Result<Calibration, DeviceError<SPI::Error>> {
+        let mut prom_data = [0u16; 8];
+        let dummy_byte = 0x00;
+        for i in 0..8 {
+            block!(spi.write(Command::ReadPROM(i as u8).value())).map_err(DeviceError::Spi)?;
+            block!(spi.write(dummy_byte)).map_err(DeviceError::Spi)?;
+            let msb = block!(spi.read()).map_err(DeviceError::Spi)?;
+            block!(spi.write(dummy_byte)).map_err(DeviceError::Spi)?;
+            let lsb = block!(spi.read()).map_err(DeviceError::Spi)?;
+            prom_data[i] = u16::from_be_bytes([msb, lsb]);
+        }
+        let mut prom_data_for_crc = prom_data;
+        if !Self::validate_crc4(&mut prom_data_for_crc) {
+            return Err(DeviceError::InvalidCRC);
+        }
+        Ok(Calibration::new(&prom_data))
+    }
+
+    /// Sets the oversampling ratio for subsequent conversions.
     pub fn set_oversampling_ratio(&mut self, ratio: OversamplingRatio) {
         self.oversampling_ratio = ratio;
     }
 
-    pub fn reset(&mut self) -> Result<(), DeviceError> {
-        self.spi
-            .send(Command::Reset.value())
-            .map_err(|_| DeviceError::Io)
+    /// Gets the currently configured oversampling ratio.
+    pub fn get_oversampling_ratio(&self) -> OversamplingRatio {
+        self.oversampling_ratio.clone()
     }
 
-    fn read_digital_temp(&mut self) -> Result<u32, DeviceError> {
-        // send d2 conversion command
-        // wait for conversion
-        // read digital temperature
-        self.spi
-            .send(Command::D2Conversion(self.oversampling_ratio.clone()).value())
-            .map_err(|_| DeviceError::Io)?;
+    /// Sends the reset command to the sensor.
+    ///
+    /// **IMPORTANT:** The caller MUST wait approximately 3ms after this function
+    /// returns successfully before calling `calibrate()` or any other command.
+    pub fn reset(&mut self) -> Result<(), DeviceError<SPI::Error>> {
+        block!(self.spi.write(Command::Reset.value())).map_err(DeviceError::Spi)
+    }
 
-        let mut temp_buf = [0u8; 4];
+    /// Sends the command to start a D2 (Temperature) conversion.
+    ///
+    /// **IMPORTANT:** After calling this function, the caller MUST wait for the
+    /// conversion to complete before calling `read_adc_result()`.
+    /// The required delay depends on the current OSR setting. Use
+    /// `get_oversampling_ratio().delay_ms()` to find the typical delay needed (in milliseconds).
+    pub fn start_temp_conversion(&mut self) -> Result<(), DeviceError<SPI::Error>> {
+        let conversion_cmd = Command::D2Conversion(self.oversampling_ratio.clone()).value();
+        block!(self.spi.write(conversion_cmd)).map_err(DeviceError::Spi)?;
+        Ok(())
+    }
 
-        self.spi
-            .send(Command::ReadADC.value())
-            .map_err(|_| DeviceError::Io)?;
+    /// Sends the command to start a D1 (Pressure) conversion.
+    ///
+    /// **IMPORTANT:** After calling this function, the caller MUST wait for the
+    /// conversion to complete before calling `read_adc_result()`.
+    /// The required delay depends on the current OSR setting. Use
+    /// `get_oversampling_ratio().delay_ms()` to find the typical delay needed (in milliseconds).
+    pub fn start_pressure_conversion(&mut self) -> Result<(), DeviceError<SPI::Error>> {
+        let conversion_cmd = Command::D1Conversion(self.oversampling_ratio.clone()).value();
+        block!(self.spi.write(conversion_cmd)).map_err(DeviceError::Spi)?;
+        Ok(())
+    }
 
-        for i in 0..temp_buf.len() {
-            temp_buf[i] = self.spi.read().map_err(|_| DeviceError::Io)?;
+    /// Reads the 24-bit result from the sensor's ADC.
+    ///
+    /// **IMPORTANT:** This function should only be called *after* a conversion
+    /// (`start_temp_conversion` or `start_pressure_conversion`) has been initiated
+    /// AND the required conversion delay has elapsed (handled externally by the caller).
+    /// Calling this too early will result in an invalid reading.
+    ///
+    /// # Returns
+    /// The raw 24-bit ADC value (padded to u32).
+    pub fn read_adc_result(&mut self) -> Result<u32, DeviceError<SPI::Error>> {
+        let dummy_byte = 0x00;
+        let mut adc_read_buf = [0u8; 3];
+        block!(self.spi.write(Command::ReadADC.value())).map_err(DeviceError::Spi)?;
+        for byte_val in adc_read_buf.iter_mut() {
+            block!(self.spi.write(dummy_byte)).map_err(DeviceError::Spi)?;
+            *byte_val = block!(self.spi.read()).map_err(DeviceError::Spi)?;
         }
-        Ok(u32::from_be_bytes(temp_buf))
+        Ok(u32::from_be_bytes([
+            0,
+            adc_read_buf[0],
+            adc_read_buf[1],
+            adc_read_buf[2],
+        ]))
     }
 
-    fn read_digital_pressure(&mut self) -> Result<u32, DeviceError> {
-        let mut temp_buf = [0u8; 4];
+    /// Calculates the compensated pressure and temperature using the provided
+    /// raw D1 (pressure) and D2 (temperature) ADC values and the stored calibration data.
+    ///
+    /// This function performs the 1st and 2nd order compensation calculations.
+    /// It requires that `calibrate()` was called successfully beforehand.
+    ///
+    /// # Arguments
+    /// * `d1_raw` - The raw 24-bit pressure ADC reading (obtained via `read_adc_result` after `start_pressure_conversion` and delay).
+    /// * `d2_raw` - The raw 24-bit temperature ADC reading (obtained via `read_adc_result` after `start_temp_conversion` and delay).
+    ///
+    /// # Returns
+    /// A tuple `(pressure, temperature)` on success:
+    /// * `pressure`: Pressure in Pascals (Pa). (100 Pa = 1 mbar).
+    /// * `temperature`: Temperature in hundredths of degrees Celsius (e.g., 2007 means 20.07 °C).
+    ///
+    /// # Errors
+    /// Returns `DeviceError::Uncalibrated` if the driver hasn't been successfully calibrated.
+    /// May return `DeviceError::{Under/Over}{Temperature/Pressure}` if the final
+    /// calculated values fall outside the sensor's operating range.
+    pub fn calculate_compensated_data(
+        &self, // Takes &self because it only reads calibration
+        d1_raw: u32,
+        d2_raw: u32,
+    ) -> Result<(i32, i32), DeviceError<SPI::Error>> {
+        // Ensure calibration data is valid
+        let cal = match self.calibration {
+            Ok(c) => c,
+            Err(ref e) => return Err(e.clone()), // Return stored calibration error
+        };
 
-        self.spi
-            .send(Command::D1Conversion(self.oversampling_ratio.clone()).value())
-            .map_err(|_| DeviceError::Io)?;
+        // --- Start Calculation (using i64 for intermediate values) ---
+        let dt: i64 = d2_raw as i64 - (cal.t_ref as i64 * (1 << 8));
+        let mut temp: i64 = 2000 + (dt * cal.temp_sens as i64 / (1 << 23));
+        let mut off: i64 = (cal.off_t1 as i64 * (1 << 16)) + (cal.tco as i64 * dt / (1 << 7));
+        let mut sens: i64 = (cal.sens_t1 as i64 * (1 << 15)) + (cal.tcs as i64 * dt / (1 << 8));
 
-        self.spi
-            .send(Command::ReadADC.value())
-            .map_err(|_| DeviceError::Io)?;
+        // --- Second Order Compensation ---
+        let mut t2: i64 = 0;
+        let mut off2: i64 = 0;
+        let mut sens2: i64 = 0;
+        if temp < 2000 {
+            t2 = dt.saturating_mul(dt) / (1i64 << 31);
+            off2 = 5 * (temp - 2000).saturating_pow(2) / 2;
+            sens2 = 5 * (temp - 2000).saturating_pow(2) / 4;
+            if temp < -1500 {
+                off2 += 7 * (temp + 1500).saturating_pow(2);
+                sens2 += 11 * (temp + 1500).saturating_pow(2) / 2;
+            }
+        }
+        temp -= t2;
+        off -= off2;
+        sens -= sens2;
 
-        for i in 0..temp_buf.len() {
-            temp_buf[i] = self.spi.read().map_err(|_| DeviceError::Io)?;
+        let p: i64 = ((d1_raw as i64 * sens / (1 << 21)) - off) / (1 << 15);
+
+        // --- Range Checks ---
+        if temp < -4000 {
+            return Err(DeviceError::UnderTemperature);
+        }
+        if temp > 8500 {
+            return Err(DeviceError::OverTemperature);
+        }
+        if p < 1000 {
+            return Err(DeviceError::UnderPressure);
+        }
+        if p > 120000 {
+            return Err(DeviceError::OverPressure);
         }
 
-        Ok(u32::from_be_bytes(temp_buf))
+        Ok((p as i32, temp as i32))
     }
 
-    fn get_temperature_uncompensated(&mut self) -> Result<(i32, i32), DeviceError> {
-        // Read digital temperature
-        // Calculate temperature
-        let digital_temp = self.read_digital_temp()?;
-
-        if let Ok(ref calibration) = self.calibration {
-            let d_t: i32 = digital_temp as i32 - calibration.t_ref as i32;
-            let temp = 2000 + d_t * calibration.temp_sens as i32 / 2_i32.pow(23);
-            return Ok((temp, d_t));
-        }
-        Err(DeviceError::Uncalibrated)
-    }
-
-    /// Second Order Temperature Compensation
-    fn temp_compensate(&self, temp: i32, d_t: i32) -> Result<(i32, i64, i64), DeviceError> {
-        // We assume that we are in high temperature unless sensed otherwise.
-        // I don't really like how this is just mutables galore.
-        if let Ok(ref calibration) = self.calibration {
-            let mut t2: i32 = 0;
-            let mut off2: i64 = 0;
-            let mut sens2: i64 = 0;
-
-            // temperature compensation
-            if temp < 20 {
-                t2 = d_t.pow(2) / (2_i32).pow(31);
-                off2 = 5 * (temp as i64 - 2000).pow(2) / 2; // datasheet is / 2^1.
-                sens2 = 5 * (temp as i64 - 2000).pow(2) / 4; // datasheet is / 2^2.
-                if temp < -15 {
-                    off2 += 7 * (temp as i64 + 1500).pow(2);
-                    sens2 += 11 * (temp as i64 + 1500).pow(2) / 2;
+    /// Validates CRC4. Internal helper function.
+    fn validate_crc4(prom_data: &mut [u16; 8]) -> bool {
+        let mut n_rem = 0u16;
+        let crc_read = prom_data[7] & 0x000F;
+        prom_data[7] &= 0xFF00;
+        for i in 0..16 {
+            if i % 2 == 0 {
+                n_rem ^= prom_data[i / 2] >> 8;
+            } else {
+                n_rem ^= prom_data[i / 2] & 0x00FF;
+            }
+            for _bit in 0..8 {
+                if n_rem & 0x8000 != 0 {
+                    n_rem = (n_rem << 1) ^ 0x3000;
+                } else {
+                    n_rem <<= 1;
                 }
             }
-            Ok((
-                temp - t2,
-                calibration.off as i64 - off2,
-                calibration.sens as i64 - sens2,
-            ))
-        } else {
-            Err(DeviceError::Uncalibrated)
         }
+        let crc_calculated = (n_rem >> 12) & 0x000F;
+        crc_calculated == crc_read
     }
-
-    /// Returns (pressure mbar, temperature celcius)
-    pub fn get_data(&mut self) -> Result<(i32, i32), DeviceError> {
-        let (temp, d_t) = self.get_temperature_uncompensated()?;
-        let (temp, mut off, mut sens) = self.temp_compensate(temp, d_t)?;
-        let d1 = self.read_digital_pressure().unwrap();
-        if let Ok(ref calibration) = self.calibration {
-            off += calibration.tco as i64 * d_t as i64;
-            sens += calibration.tcs as i64 * d_t as i64;
-            let p = d1 as i64 * sens - off;
-            return Ok((p as i32, temp));
-        }
-        Err(DeviceError::Uncalibrated)
-    }
-}
-
-/// CRC4 is calculated from the 16 bits of the PROM. The CRC is calculated by the polynomial x^4 + x^3 + x^2 + 1.
-/// This should live elsewhere since it's not really a method of the device.
-fn crc4(prom: &mut [u16; 8]) -> bool {
-    let mut n_rem = 0_u16;
-    let crc_read = prom[7] & 0xF; // last 4 bits
-    prom[7] = prom[7] & 0xFF00; // clear last 4 bits
-    for i in 0..16 {
-        if i % 2 == 1 {
-            n_rem ^= prom[i >> 1] & 0x00FF;
-        } else {
-            n_rem ^= prom[i >> 1] >> 8;
-        }
-        for _ in 0..8 {
-            if n_rem & 0x8000 != 0 {
-                n_rem = (n_rem << 1) ^ 0x3000;
-            } else {
-                n_rem = n_rem << 1;
-            }
-        }
-    }
-    n_rem = n_rem >> 12;
-    n_rem ^= 0x00;
-    crc_read == n_rem
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn check_command_d1_conversion() {
-        let mut command = Command::D1Conversion(OversamplingRatio::OSR1024);
-        assert_eq!(command.value(), 0x44);
-        command = Command::D1Conversion(OversamplingRatio::OSR256);
-        assert_eq!(command.value(), 0x40);
-        command = Command::D1Conversion(OversamplingRatio::OSR512);
-        assert_eq!(command.value(), 0x42);
-    }
-
-    #[test]
-    fn check_command_d2_conversion() {
-        let mut command = Command::D2Conversion(OversamplingRatio::OSR1024);
-        assert_eq!(command.value(), 0x54);
-        command = Command::D2Conversion(OversamplingRatio::OSR256);
-        assert_eq!(command.value(), 0x50);
-        command = Command::D2Conversion(OversamplingRatio::OSR512);
-        assert_eq!(command.value(), 0x52);
-    }
-
-    #[test]
-    fn check_command_read_prom() {
-        let mut command = Command::ReadPROM(0, 1, 0);
-        assert_eq!(command.value(), 0xA4);
-        command = Command::ReadPROM(1, 1, 1);
-        assert_eq!(command.value(), 0xAE);
-    }
-
-    #[test]
-    fn check_temp_compensation() {}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,10 @@ use core::fmt::Debug;
 use embedded_hal::blocking::delay::DelayMs;
 use error::DeviceError;
 
-pub struct MS5611_01BA<SPI> {
+pub struct MS5611_01BA<SPI>
+where
+    SPI: FullDuplex<u16, Error = SPI> + Debug,
+{
     spi: SPI,
     calibration: Result<Calibration, DeviceError<SPI>>, // a user can choose to calibrate the device
     oversampling_ratio: OversamplingRatio,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,6 @@ pub mod command;
 pub mod error;
 use calibration::{Calibration, OversamplingRatio};
 use command::Command;
-use core::fmt::Debug;
 use embedded_hal::blocking::delay::DelayMs;
 use error::DeviceError;
 
@@ -20,8 +19,7 @@ where
 
 impl<SPI> MS5611_01BA<SPI>
 where
-    SPI: FullDuplex<u8> + Debug,
-    <SPI as FullDuplex<u8>>::Error: Debug,
+    SPI: FullDuplex<u8>,
 {
     /// Create a new instance of the MS5611_01BA03
     /// Clock speed must not exceed 20MHz

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,8 @@ use error::DeviceError;
 
 pub struct MS5611_01BA<SPI>
 where
-    SPI: FullDuplex<u16, Error = SPI> + Debug,
+    SPI: FullDuplex<u16>,
+    <SPI as FullDuplex<u16>>::Error: Debug,
 {
     spi: SPI,
     calibration: Result<Calibration, DeviceError<SPI>>, // a user can choose to calibrate the device

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ use error::DeviceError;
 
 pub struct MS5611_01BA<SPI>
 where
-    SPI: FullDuplex<u8> + Debug,
+    SPI: FullDuplex<u8>,
 {
     spi: SPI,
     calibration: Result<Calibration, DeviceError>, // a user can choose to calibrate the device


### PR DESCRIPTION
Refactors the driver API to correctly work within the constraints of embedded_hal_nb::spi::FullDuplex without an internal DelayNs provider.

The previous structure attempted to combine "start conversion" and "read result" operations within single functions (e.g., `read_digital_temp`). This is unfeasible because the sensor requires a specific delay between these steps, which depends on the selected Oversampling Ratio (OSR). Without a DelayNs trait provided to the driver, it cannot perform these waits internally, leading to incorrect (likely zero) readings if used as originally written.

- Separated sensor interactions into distinct steps:
  - `start_temp_conversion()` / `start_pressure_conversion()`
  - `read_adc_result()`
- Removed the internal functions (`read_digital_temp`, `read_digital_pressure`).
- Introduced `calculate_compensated_data()` to perform calculations using raw ADC values provided by the caller.
- Updated documentation to clearly state that the caller is now responsible for inserting the appropriate delay (based on OSR) between starting a conversion and reading the result.